### PR TITLE
Set GPIO using the GPIO commands, I2C use Exceptions instead of exiting

### DIFF
--- a/PyMCP2221A/PyMCP2221A.py
+++ b/PyMCP2221A/PyMCP2221A.py
@@ -1,9 +1,3 @@
-# Stolen from https://github.com/nonNoise/PyMCP2221A/blob/master/PyMCP2221A/PyMCP2221A.py
-# MODIFIED BY MONOGRAM:
-# Added Exception in I2C_Init instead of SystemExit
-# Restored time.sleep() in _i2c_read
-# Changed GPIO implementation in reference to https://lkml.org/lkml/2020/4/14/1004
-
 #############################################################
 #    MIT License                                            #
 #    Copyright (c) 2017 Yuta KItagami                       #
@@ -581,7 +575,7 @@ class PyMCP2221A:
         self.mcp2221a.write(buf)
         rbuf = self.mcp2221a.read(65)
         if (rbuf[1] != 0x00):
-            print("[0x91:0x{:02x},0x{:02x},0x{:02x}]".format(rbuf[1],rbuf[2],rbuf[3]))
+            # print("[0x91:0x{:02x},0x{:02x},0x{:02x}]".format(rbuf[1],rbuf[2],rbuf[3]))
             self.I2C_Cancel()
             self.I2C_Init()
             raise RuntimeError("I2C Read Data Failed: Code " + rbuf[1])
@@ -594,7 +588,7 @@ class PyMCP2221A:
         self.mcp2221a.write(buf)
         rbuf = self.mcp2221a.read(65)
         if (rbuf[1] != 0x00):
-            print("[0x40:0x{:02x},0x{:02x},0x{:02x}]".format(rbuf[1],rbuf[2],rbuf[3]))
+            # print("[0x40:0x{:02x},0x{:02x},0x{:02x}]".format(rbuf[1],rbuf[2],rbuf[3]))
             self.I2C_Cancel()
             self.I2C_Init()
             print("You can try increasing environment variable MCP2221_I2C_SLEEP")

--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,12 @@ Example
 
     https://github.com/nonNoise/PyMCP2221A/blob/master/example/MCP2221_EEPROM_WriteReadTest.py
 
+    Note you can change the system enviornment variable for I2C read delay if 
+    you are running into I2C problems.
+    
+    import os
+    os.environ["MCP2221_I2C_SLEEP"] = "0.05"
+
 
 
 

--- a/example/MCP2221_GPIO.py
+++ b/example/MCP2221_GPIO.py
@@ -11,12 +11,14 @@ print('-'*20)
 gpio = PyMCP2221A.PyMCP2221A()
 gpio.GPIO_Init()
 gpio.GPIO_0_OutputMode()
+gpio.GPIO_3_InputMode()
 print(" CTRL+C keys to exit.")
 while 1:
-    gpio.GPIO_3_Output(1)
-    time.sleep(0.1)
-    gpio.GPIO_3_Output(0)
-    time.sleep(0.1)
+    if gpio.GPIO_3_Input()[0]:
+        # Note that GPIO_3_Input() returns a tuple
+        # GPIO_GetValue() is available if you don't need to know
+        # what the Direction is
+        print("GPIO 3 is HIGH!")
     gpio.GPIO_2_Output(1)
     time.sleep(0.1)
     gpio.GPIO_2_Output(0)


### PR DESCRIPTION
1. Instead using SRAM Setting `0x60 Set SRAM settings` and `0x61` to set the GPIO direction and state, use the `0x50 Set GPIO Output Values` command. (like the Linux kernel [driver](https://lkml.org/lkml/2020/4/14/1004)). Using the SRAM commands is harder to debug. Also make available a function that returns the GPIO state by an integer rather than tuple. 
2. I was having trouble with I2C not working because for my application I need the `time.sleep()` in `_i2c_read()`. I made this an environment variable so people can use it as they please
3. The `exit()` in `I2C_Init()` has been removed and changed with exception, so the program no longer exits on error
4. `_i2c_read()` now raises error if the return code from MCP2221 is not `0x00`, instead of returning `-1`. An alternative is to have `_i2c_read()` return `None`. I think smbus returns `None` ? Not too sure. 

Updated example and readme as appropriate 