### PR TITLE
One source multi setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+
+init:
+	mkdir -p build dist
+
+build-arm:
+	cp LICENSE README.rst pypi/armv7l/
+	cp PyMCP2221A/* pypi/armv7l/PyMCP2221A
+	cd pypi/armv7l && python3 setup.py bdist_wheel
+
+build-x86_64:
+	cp LICENSE README.rst pypi/main/
+	cp PyMCP2221A/* pypi/main/PyMCP2221A
+	cd pypi/main && python3 setup.py bdist_wheel
+
+clean:
+	rm -r pypi/*/build/*
+	rm -r pypi/*/dist/*
+	rm -r pypi/*/*.egg-info

--- a/PyMCP2221A/PyMCP2221A.py
+++ b/PyMCP2221A/PyMCP2221A.py
@@ -4,14 +4,15 @@
 #############################################################
 
 import hid
-#import hid
+# import hid
 # pip install hidapi
 # https://github.com/trezor/cython-hidapi
 import time
 import os
 
+
 class PyMCP2221A:
-    def __init__(self,VID = 0x04D8,PID = 0x00DD,devnum = 0):
+    def __init__(self, VID=0x04D8, PID=0x00DD, devnum=0):
         self.mcp2221a = hid.device()
         self.mcp2221a.open_path(hid.enumerate(VID, PID)[devnum]["path"])
         self.CLKDUTY_0 = 0x00
@@ -19,25 +20,25 @@ class PyMCP2221A:
         self.CLKDUTY_50 = 0x10
         self.CLKDUTY_75 = 0x18
         # self.CLKDIV_1 = 0x00    # 48MHz  Dont work.
-        self.CLKDIV_2 = 0x01    # 24MHz
-        self.CLKDIV_4 = 0x02    # 12MHz
-        self.CLKDIV_8 = 0x03    # 6MHz
-        self.CLKDIV_16 = 0x04   # 3MHz
-        self.CLKDIV_32 = 0x05   # 1.5MHz
-        self.CLKDIV_64 = 0x06   # 750KHz
+        self.CLKDIV_2 = 0x01  # 24MHz
+        self.CLKDIV_4 = 0x02  # 12MHz
+        self.CLKDIV_8 = 0x03  # 6MHz
+        self.CLKDIV_16 = 0x04  # 3MHz
+        self.CLKDIV_32 = 0x05  # 1.5MHz
+        self.CLKDIV_64 = 0x06  # 750KHz
         self.CLKDIV_128 = 0x07  # 375KHz
-#######################################################################
-# HID DeviceDriver Info
-#######################################################################
+
+    #######################################################################
+    # HID DeviceDriver Info
+    #######################################################################
     def DeviceDriverInfo(self):
         print("Manufacturer: %s" % self.mcp2221a.get_manufacturer_string())
         print("Product: %s" % self.mcp2221a.get_product_string())
-        print("Serial No: %s" % self.mcp2221a.get_serial_number_string())        
-        
+        print("Serial No: %s" % self.mcp2221a.get_serial_number_string())
 
-#######################################################################
-# Command Structure
-#######################################################################
+    #######################################################################
+    # Command Structure
+    #######################################################################
     def Command_Structure(self, I2C_Cancel_Bit, I2C_Speed_SetUp_Bit, I2C_Speed_SetVal_Byte):
         I2C_Cancel_Bit = 0
         I2C_Speed_SetUp_Bit = 0
@@ -47,13 +48,14 @@ class PyMCP2221A:
         self.mcp2221a.write(buf)
         buf = self.mcp2221a.read(65)
 
-        print (chr(buf[46]))
-        print (chr(buf[47]))
-        print (chr(buf[48]))
-        print (chr(buf[49]))
-#######################################################################
-# Read Flash Data
-#######################################################################
+        print(chr(buf[46]))
+        print(chr(buf[47]))
+        print(chr(buf[48]))
+        print(chr(buf[49]))
+
+    #######################################################################
+    # Read Flash Data
+    #######################################################################
 
     def Read_Flash_Data(self, Read_Deta_Setting_Byte):
         Read_Deta_Setting_Byte = 0x00
@@ -71,9 +73,10 @@ class PyMCP2221A:
         buf = self.mcp2221a.read(65)
         # print ("Read")
         # print (buf)
-#######################################################################
-# Write Flash Data
-#######################################################################
+
+    #######################################################################
+    # Write Flash Data
+    #######################################################################
 
     def Write_Flash_Data(self, data):
         pass
@@ -98,9 +101,9 @@ class PyMCP2221A:
         # print ("Read")
         # print (buf)
 
-#######################################################################
-# GPIO Init
-#######################################################################
+    #######################################################################
+    # GPIO Init
+    #######################################################################
     def GPIO_Init(self):
         buf = [0x00, 0x61]
         buf = buf + [0 for i in range(65 - len(buf))]
@@ -117,17 +120,17 @@ class PyMCP2221A:
         buf[7 + 1] = 0x80  # Alter GPIO configuration: alters the current GP designation
         #   datasheet says this should be 1, but should actually be 0x80
 
-        self.GPIO_0_BIT = (rbuf[22 + 1] >> 4) & 0x01      # 1:Hi 0:LOW
-        self.GPIO_0_DIR = (rbuf[22 + 1] >> 3) & 0x01      # 0:OutPut 1:Input
+        self.GPIO_0_BIT = (rbuf[22 + 1] >> 4) & 0x01  # 1:Hi 0:LOW
+        self.GPIO_0_DIR = (rbuf[22 + 1] >> 3) & 0x01  # 0:OutPut 1:Input
         self.GPIO_0_MODE = rbuf[22 + 1] & 0x07  # GPIO MODE = 0x00
-        self.GPIO_1_BIT = (rbuf[23 + 1] >> 4) & 0x01      # 1:Hi 0:LOW
-        self.GPIO_1_DIR = (rbuf[23 + 1] >> 3) & 0x01      # 0:OutPut 1:Input
+        self.GPIO_1_BIT = (rbuf[23 + 1] >> 4) & 0x01  # 1:Hi 0:LOW
+        self.GPIO_1_DIR = (rbuf[23 + 1] >> 3) & 0x01  # 0:OutPut 1:Input
         self.GPIO_1_MODE = rbuf[23 + 1] & 0x07  # GPIO MODE = 0x00
-        self.GPIO_2_BIT = (rbuf[24 + 1] >> 4) & 0x01      # 1:Hi 0:LOW
-        self.GPIO_2_DIR = (rbuf[24 + 1] >> 3) & 0x01      # 0:OutPut 1:Input
+        self.GPIO_2_BIT = (rbuf[24 + 1] >> 4) & 0x01  # 1:Hi 0:LOW
+        self.GPIO_2_DIR = (rbuf[24 + 1] >> 3) & 0x01  # 0:OutPut 1:Input
         self.GPIO_2_MODE = rbuf[24 + 1] & 0x07  # GPIO MODE = 0x00
-        self.GPIO_3_BIT = (rbuf[25 + 1] >> 4) & 0x01      # 1:Hi 0:LOW
-        self.GPIO_3_DIR = (rbuf[25 + 1] >> 3) & 0x01      # 0:OutPut 1:Input
+        self.GPIO_3_BIT = (rbuf[25 + 1] >> 4) & 0x01  # 1:Hi 0:LOW
+        self.GPIO_3_DIR = (rbuf[25 + 1] >> 3) & 0x01  # 0:OutPut 1:Input
         self.GPIO_3_MODE = rbuf[25 + 1] & 0x07  # GPIO MODE = 0x00
 
         # for(i in range(64)):
@@ -135,10 +138,9 @@ class PyMCP2221A:
         self.mcp2221a.write(buf)
         buf = self.mcp2221a.read(65)
 
-
-#######################################################################
-# GPIO Set Direction and Set Value commands
-#######################################################################
+    #######################################################################
+    # GPIO Set Direction and Set Value commands
+    #######################################################################
     def GPIO_SetDirection(self, pin, direction):
         buf = [0x00, 0x50]
         buf = buf + [0 for i in range(65 - len(buf))]
@@ -161,9 +163,9 @@ class PyMCP2221A:
         if rbuf[1] != 0x00:
             raise RuntimeError("GPIO_SetValue Failed")
 
-#######################################################################
-# Read GPIO Data command
-#######################################################################
+    #######################################################################
+    # Read GPIO Data command
+    #######################################################################
     def GPIO_Read(self):
         buf = [0x00, 0x51]
         buf = buf + [0 for i in range(65 - len(buf))]
@@ -178,7 +180,7 @@ class PyMCP2221A:
         self.GPIO_3_INPUT = buf[8]
         self.GPIO_3_DIR = buf[9]
         return buf
-    
+
     # Return the GPIO value as an integer instead of tuple
     def GPIO_GetValue(self, pin):
         rbuf = self.GPIO_Read()
@@ -187,9 +189,9 @@ class PyMCP2221A:
             raise RuntimeError("GPIO_GetValue Failed, pin is not set for GPIO operation")
         return rbuf[offset]
 
-#######################################################################
-# GPIO Outpu/Input Data
-#######################################################################
+    #######################################################################
+    # GPIO Outpu/Input Data
+    #######################################################################
     def GPIO_0_Output(self, bit):
         self.GPIO_0_BIT = bit  # 1:Hi 0:LOW
         self.GPIO_0_DIR = 0  # 0:OutPut 1:Input
@@ -262,10 +264,9 @@ class PyMCP2221A:
         self.GPIO_Read()
         return self.GPIO_3_INPUT, self.GPIO_3_DIR
 
-
-#######################################################################
-# Clock Out Value & Duty
-#######################################################################
+    #######################################################################
+    # Clock Out Value & Duty
+    #######################################################################
     def ClockOut(self, duty, value):
         buf = [0x00, 0x61]
         buf = buf + [0 for i in range(65 - len(buf))]
@@ -288,9 +289,9 @@ class PyMCP2221A:
         self.mcp2221a.write(buf)
         buf = self.mcp2221a.read(65)
 
-#######################################################################
-# ADC 1
-#######################################################################
+    #######################################################################
+    # ADC 1
+    #######################################################################
     def ADC_1_Init(self):
         buf = [0x00, 0x61]
         buf = buf + [0 for i in range(65 - len(buf))]
@@ -312,9 +313,10 @@ class PyMCP2221A:
         buf[11 + 1] = rbuf[25]  # GP3 settings
         self.mcp2221a.write(buf)
         buf = self.mcp2221a.read(65)
-#######################################################################
-# ADC 2
-#######################################################################
+
+    #######################################################################
+    # ADC 2
+    #######################################################################
 
     def ADC_2_Init(self):
         buf = [0x00, 0x61]
@@ -337,9 +339,10 @@ class PyMCP2221A:
         buf[11 + 1] = rbuf[25]  # GP3 settings
         self.mcp2221a.write(buf)
         buf = self.mcp2221a.read(65)
-#######################################################################
-# ADC 3
-#######################################################################
+
+    #######################################################################
+    # ADC 3
+    #######################################################################
 
     def ADC_3_Init(self):
         buf = [0x00, 0x61]
@@ -362,9 +365,10 @@ class PyMCP2221A:
         buf[11 + 1] = 0x02  # GP3 settings
         self.mcp2221a.write(buf)
         buf = self.mcp2221a.read(65)
-#######################################################################
-# ADC Deta Get
-#######################################################################
+
+    #######################################################################
+    # ADC Deta Get
+    #######################################################################
 
     def ADC_DataRead(self):
         buf = [0x00, 0x10]
@@ -377,9 +381,9 @@ class PyMCP2221A:
         self.ADC_2_data = buf[52] | (buf[53] << 8)  # ADC Data (16-bit) values
         self.ADC_3_data = buf[54] | (buf[55] << 8)  # ADC Data (16-bit) values
 
-#######################################################################
-# DAC 1
-#######################################################################
+    #######################################################################
+    # DAC 1
+    #######################################################################
     def DAC_1_Init(self):
         buf = [0x00, 0x61]
         buf = buf + [0 for i in range(65 - len(buf))]
@@ -401,9 +405,10 @@ class PyMCP2221A:
         buf[11 + 1] = rbuf[25]  # GP3 settings
         self.mcp2221a.write(buf)
         buf = self.mcp2221a.read(65)
-#######################################################################
-# DAC 2
-#######################################################################
+
+    #######################################################################
+    # DAC 2
+    #######################################################################
 
     def DAC_2_Init(self):
         buf = [0x00, 0x61]
@@ -426,9 +431,10 @@ class PyMCP2221A:
         buf[11 + 1] = 0x03  # GP3 settings
         self.mcp2221a.write(buf)
         buf = self.mcp2221a.read(65)
-#######################################################################
-# DAC Output
-#######################################################################
+
+    #######################################################################
+    # DAC Output
+    #######################################################################
 
     def DAC_Datawrite(self, value):
         buf = [0x00, 0x61]
@@ -452,10 +458,9 @@ class PyMCP2221A:
         self.mcp2221a.write(buf)
         buf = self.mcp2221a.read(65)
 
-
-#######################################################################
-# I2C Init
-#######################################################################
+    #######################################################################
+    # I2C Init
+    #######################################################################
     def I2C_Init(self, speed=100000):  # speed = 100000
         self.MCP2221_I2C_SLEEP = float(os.environ.get("MCP2221_I2C_SLEEP", 0))
 
@@ -468,25 +473,26 @@ class PyMCP2221A:
         self.mcp2221a.write(buf)
         rbuf = self.mcp2221a.read(65)
         # print("Init")
-        if(rbuf[22] == 0):
+        if (rbuf[22] == 0):
             raise RuntimeError("SCL is low.")
-        if(rbuf[23] == 0):
+        if (rbuf[23] == 0):
             raise RuntimeError("SDA is low.")
 
         # time.sleep(0.001)
 
-#######################################################################
-# I2C State Check
-#######################################################################
+    #######################################################################
+    # I2C State Check
+    #######################################################################
     def I2C_State_Check(self):
         buf = [0x00, 0x10]
         buf = buf + [0 for i in range(65 - len(buf))]
         self.mcp2221a.write(buf)
         rbuf = self.mcp2221a.read(65)
         return rbuf[8]
-#######################################################################
-# I2C Cancel
-#######################################################################
+
+    #######################################################################
+    # I2C Cancel
+    #######################################################################
 
     def I2C_Cancel(self):
         buf = [0x00, 0x10]
@@ -496,22 +502,22 @@ class PyMCP2221A:
         self.mcp2221a.read(65)
         # time.sleep(0.1)
 
-#######################################################################
-# I2C Write
-#######################################################################
+    #######################################################################
+    # I2C Write
+    #######################################################################
     def I2C_Write(self, addrs, data):
         """ Writes a block of data with Start and Stop c condition on bus
-        :param int addrs: 8-bit I2C slave address
+        :param int addrs: 7-bit I2C slave address
         :param list data: list of int
 
         Referring to MCP2221A Datasheet(Rev.B 2017), section 3.1.5
         """
         buf = [0x00, 0x90]
         self._i2c_write(addrs, data, buf)
-        
+
     def I2C_Write_Repeated(self, addrs, data):
         """ Writes a block of data with Repeated Start and Stop conditions on bus
-        :param int addrs: 8-bit I2C slave address
+        :param int addrs: 7-bit I2C slave address
         :param list data: list of int
 
         Referring to MCP2221A Datasheet(Rev.B 2017), section 3.1.6
@@ -521,7 +527,7 @@ class PyMCP2221A:
 
     def I2C_Write_No_Stop(self, addrs, data):
         """ Writes a block of data with Start condition on bus
-        :param int addrs: 8-bit I2C slave address
+        :param int addrs: 7-bit I2C slave address
         :param list data: list of int
 
         Referring to MCP2221A Datasheet(Rev.B 2017), section 3.1.7
@@ -537,18 +543,18 @@ class PyMCP2221A:
         buf[3 + 1] = 0xFF & (addrs << 1)
         for i in range(len(data)):
             # print ("{:d}: 0x{:02x}".format(i,data[i]))
-            buf[4 + 1 + i] = data[i]  # The I2C/SMBus system clock divider that will be used to establish the communication speed
+            buf[4 + 1 + i] = data[
+                i]  # The I2C/SMBus system clock divider that will be used to establish the communication speed
         self.mcp2221a.write(buf)
         rbuf = self.mcp2221a.read(65)
         time.sleep(0.008)
 
-
-#######################################################################
-# I2C Read
-#######################################################################
+    #######################################################################
+    # I2C Read
+    #######################################################################
     def I2C_Read(self, addrs, size):
         """ Reads a block of data with Start and Stop conditions on bus
-        :param int addrs: 8-bit I2C slave address
+        :param int addrs: 7-bit I2C slave address
         :param int size: size of read out in bytes
 
         Referring to MCP2221A Datasheet(Rev.B 2017), section 3.1.8
@@ -558,7 +564,7 @@ class PyMCP2221A:
 
     def I2C_Read_Repeated(self, addrs, size):
         """ Reads a block of data with Repeated Start and Stop conditions on bus
-        :param int addrs: 8-bit I2C slave address
+        :param int addrs: 7-bit I2C slave address
         :param int size: size of read out in bytes
 
         Referring to MCP2221A Datasheet(Rev.B 2017), section 3.1.9
@@ -603,12 +609,11 @@ class PyMCP2221A:
                 rdata[i] = rbuf[4 + i]
             return rdata
 
-
-#######################################################################
-# reset
-#######################################################################
+    #######################################################################
+    # reset
+    #######################################################################
     def Reset(self):
-        print ("Reset")
+        print("Reset")
         buf = [0x00, 0x70, 0xAB, 0xCD, 0xEF]
         buf = buf + [0 for i in range(65 - len(buf))]
         self.mcp2221a.write(buf)

--- a/PyMCP2221A/SMBus.py
+++ b/PyMCP2221A/SMBus.py
@@ -5,33 +5,42 @@
 from PyMCP2221A import PyMCP2221A
 import time
 
-#-------------------------------------------------------------#
+
+# -------------------------------------------------------------#
 # SMBus (system management bus) function compatible function  #
-#-------------------------------------------------------------#
-class SMBus :
-    def __init__(self,VID = 0x04D8,PID = 0x00DD,devnum = 0):
-        self.mcp2221 = PyMCP2221A.PyMCP2221A(VID,PID,devnum)
+# -------------------------------------------------------------#
+class SMBus:
+    def __init__(self, VID=0x04D8, PID=0x00DD, devnum=0):
+        self.mcp2221 = PyMCP2221A.PyMCP2221A(VID, PID, devnum)
         self.mcp2221.I2C_Init()
+
     def read_byte(self, addrs):
-        return self.mcp2221.I2C_Read(addrs,1)[0]
-    def write_byte(self, addrs,val):
-        self.mcp2221.I2C_Write(addrs,1,[val])
-    def read_byte_data(self, addrs,cmd):
-        self.mcp2221.I2C_Write_No_Stop(addrs,[cmd])
-        return self.mcp2221.I2C_Read_Repeated(addrs,1)[0]
-    def write_byte_data(self, addrs,cmd,val):
-        self.mcp2221.I2C_Write(addrs,[cmd,val])
-    def read_word_data(self, addrs,cmd):
-        self.mcp2221.I2C_Write_No_Stop(addrs,[cmd])
-        tmp = self.mcp2221.I2C_Read_Repeated(addrs,2)
-        return tmp[0] | tmp[1]<<8
-    def write_word_data(self, addrs,cmd,val):
-        self.mcp2221.I2C_Write(addrs,[cmd,val&0x00FF,(val&0xFF00)>>8])
-    def read_i2c_block_data(self, addrs,cmd,size):
-        self.mcp2221.I2C_Write_No_Stop(addrs,[cmd])
-        return self.mcp2221.I2C_Read_Repeated(addrs,size)
-    def write_i2c_block_data(self, addrs,cmd,vals):
-        self.mcp2221.I2C_Write(addrs,[cmd,vals])
+        return self.mcp2221.I2C_Read(addrs, 1)[0]
+
+    def write_byte(self, addrs, val):
+        self.mcp2221.I2C_Write(addrs, [val])
+
+    def read_byte_data(self, addrs, cmd):
+        self.mcp2221.I2C_Write_No_Stop(addrs, [cmd])
+        return self.mcp2221.I2C_Read_Repeated(addrs, 1)[0]
+
+    def write_byte_data(self, addrs, cmd, val):
+        self.mcp2221.I2C_Write(addrs, [cmd, val])
+
+    def read_word_data(self, addrs, cmd):
+        self.mcp2221.I2C_Write_No_Stop(addrs, [cmd])
+        tmp = self.mcp2221.I2C_Read_Repeated(addrs, 2)
+        return tmp[0] | tmp[1] << 8
+
+    def write_word_data(self, addrs, cmd, val):
+        self.mcp2221.I2C_Write(addrs, [cmd, val & 0x00FF, (val & 0xFF00) >> 8])
+
+    def read_i2c_block_data(self, addrs, cmd, size):
+        self.mcp2221.I2C_Write_No_Stop(addrs, [cmd])
+        return self.mcp2221.I2C_Read_Repeated(addrs, size)
+
+    def write_i2c_block_data(self, addrs, cmd, vals):
+        self.mcp2221.I2C_Write(addrs, [cmd, vals])
+
     def reset(self):
         self.mcp2221.Reset()
- 


### PR DESCRIPTION
- There have been **three** _exact same_ code base ie. `/`, `/pypi/main` and `/pypi/armv7l`
- There have been two `setup.py`'s ie. for ARM and x86_64

Adding a Makefile solves the problem of which codebase should we discuss

- `make build-arm` builds wheel package for armv7l target
- `make build-x86_64` builds wheel package for x86_64 target
- during the build it copies `LICENSE`, `README.rst` and `PyMCP2221A/*` from the repository root
