### PR TITLE
PyMCP2221A.py: use complete 5 bit of DAC

### DIFF
--- a/PyMCP2221A/PyMCP2221A.py
+++ b/PyMCP2221A/PyMCP2221A.py
@@ -446,7 +446,7 @@ class PyMCP2221A:
         buf = buf + [0 for i in range(65 - len(buf))]
         buf[2 + 1] = rbuf[5]  # Clock Output Divider value
         buf[3 + 1] = 0x00  # DAC Voltage Reference
-        buf[4 + 1] = 0x80 | (0x0F & value)  # Set DAC output value
+        buf[4 + 1] = 0x80 | (0x1F & value)  # Set DAC output value
         buf[5 + 1] = rbuf[7]  # ADC Voltage Reference
         buf[6 + 1] = 0x00  # Setup the interrupt detection mechanism and clear the detection flag
         buf[7 + 1] = 0xFF  # Alter GPIO configuration: alters the current GP designation


### PR DESCRIPTION
TRM says:
CHIPSETTING2 REGISTER
bit 4-0 DACVAL<4:0>: Initial DAC Output Value
           5-bit value for the DAC output (factory default is 8 decimal)

Signed-off-by: Jan Remmet <j.remmet@phytec.de>

fixes #9 